### PR TITLE
Knip

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -1,0 +1,30 @@
+import type { KnipConfig } from "knip";
+
+const config: KnipConfig = {
+  // Too many issues with these rules to have them enabled at this time
+  exclude: ["exports", "types", "duplicates"],
+
+  ignore: [
+    // These files are treated as static assets.
+    "static/**/*",
+  ],
+
+  ignoreDependencies: [
+    // next.config.js
+    "@babel/core",
+    "@catalog/loader",
+    "raw-loader",
+    "svg-react-loader",
+
+    // tslint.json
+    "tslint-config-prettier",
+
+    // vega
+    "react-vega",
+    "react-vega-lite",
+    "vega",
+    "vega-lite",
+  ],
+};
+
+export default config;


### PR DESCRIPTION
https://knip.dev/ is a nice tool to detect unused code (whole files, but also individual functions within the files), unused dependencies, and dependencies that the project uses but are not listed explicitly in package.json (which is bad, since you're implicitly relying on code that you are not declaring in your project).

You can run it with `npx knip`. The config file is needed to disable certain rules and manually exclude some dependencies which Knip does not detect automatically. With the config in this PR, this is the output:

```
Unused files (2)
src/views.tsx
src/Views/Components/GradeBalance.tsx

Unused dependencies (4)
@types/d3      package.json:12:6
@types/page    package.json:13:6
d3-array       package.json:20:6
d3-collection  package.json:22:6

Unlisted dependencies (1)
csstype  src/Materials/Typefaces.ts
```

These warnings seem reasonable to resolve (delete unused files and dependencies, and explicitly add `csstype` to package.json).

With all rules active, Knip generates this:

```
Unused files (2)
src/views.tsx
src/Views/Components/GradeBalance.tsx

Unused dependencies (4)
@types/d3      package.json:12:6
@types/page    package.json:13:6
d3-array       package.json:20:6
d3-collection  package.json:22:6

Unlisted dependencies (1)
csstype  src/Materials/Typefaces.ts

Unused exports (13)
Config              class           src/app.ts:6:14
app                                 src/Catalog/App.ts:18:14
setter2Id                           src/Catalog/App.ts:69:14
admin1Id                            src/Catalog/App.ts:82:14
black                      C        src/Materials/Colors.ts:12:14
yellowColors               C        src/Materials/Colors.ts:16:14
greenColors                C        src/Materials/Colors.ts:20:14
orangeColors               C        src/Materials/Colors.ts:24:14
blueColors                 C        src/Materials/Colors.ts:28:14
redColors                  C        src/Materials/Colors.ts:32:14
headingFontFamily          T        src/Materials/Typefaces.ts:18:14
copyFontFamily             T        src/Materials/Typefaces.ts:57:14
setterMonthlyStats         Storage  src/storage.ts:86:14

Unused exported types (15)
GradeDistributionChartProps            interface  src/Components/GradeDistributionChart.tsx:11:18
SectorDistributionChartProps           interface  src/Components/SectorDistributionChart.tsx:10:18
SetterCardProps                        interface  src/Components/SetterBlock.tsx:14:18
SetterPickerProps                      interface  src/Components/SetterPicker.tsx:8:18
Typeface                      T        interface  src/Materials/Typefaces.ts:3:18
SetterMonthlyStats            Storage  interface  src/storage.ts:75:18
BoulderCardProps                       interface  src/Views/Components/BoulderCard.tsx:14:18
DropdownInputProps                     interface  src/Views/Components/DropdownInput.tsx:10:18
NumberInputProps                       interface  src/Views/Components/NumberInput.tsx:5:18
SectorPickerProps                      interface  src/Views/Components/SectorPicker.tsx:6:18
SetterCardProps                        interface  src/Views/Components/SetterCard.tsx:9:18
SectorSelectorProps                    interface  src/Views/Components/Stats/SectorSelector.tsx:6:18
SetterSelectorProps                    interface  src/Views/Components/Stats/SetterSelector.tsx:13:18
StatsFilterProps                       interface  src/Views/Components/Stats/StatsFilter.tsx:11:18
VisualizationProps                     interface  src/Views/Components/Stats/Visualization.tsx:27:18

Duplicate exports (1)
app, anonymousApp  src/Catalog/App.ts
```

Some of those still make sense to clean up, but others (eg. the exported *Props interfaces) are expected and I have not found a way to selectively configure Knip to allow those.