### PR TITLE
Temporarily patch crypto

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,3 +1,22 @@
+/*
+ * Patch crypto createHash to not crash in modern Node.js environments, by
+ * silently upgrading MD4 to MD5.
+ *
+ * This patch will no longer be needed once we upgrade Next.js and/or Webpack
+ * to a sufficiently modern version.
+ *
+ * https://stackoverflow.com/a/72219174
+ */
+const crypto = require("crypto");
+try {
+  crypto.createHash("md4");
+} catch (e) {
+  const origCreateHash = crypto.createHash;
+  crypto.createHash = (alg, opts) => {
+    return origCreateHash(alg === "md4" ? "md5" : alg, opts);
+  };
+}
+
 module.exports = {
   typescript: {
     ignoreDevErrors: true,


### PR DESCRIPTION
I don't know you you managed to get it running locally. Newer versions of Node.js are not compatible with old versions of Webpack. Vercel seems to have a builtin workaround for it. But I can't run the site locally without this patch. This can be removed once Next.js is upgraded to a sufficiently recent version.