### PR TITLE
Update dependabot directory configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
 - package-ecosystem: npm
-  directory: "/client"
+  directory: "/"
   schedule:
     interval: daily
     time: '04:00'


### PR DESCRIPTION
The web app is in the root and no longer under `./client/` subdirectory.