### PR TITLE
Remove custom babel config

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  presets: ["next/babel"],
-  plugins: [["styled-components", { ssr: true }]]
-};

--- a/next.config.js
+++ b/next.config.js
@@ -18,6 +18,10 @@ try {
 }
 
 module.exports = {
+  compiler: {
+    styledComponents: true,
+  },
+
   typescript: {
     ignoreBuildErrors: true,
   },
@@ -31,6 +35,5 @@ module.exports = {
     THEME_COLOR_PRIMARY: process.env.THEME_COLOR_PRIMARY || "#a5d6a7",
     THEME_COLOR_PRIMARY_TEXT: process.env.THEME_COLOR_PRIMARY_TEXT || "#333333",
     THEME_COLOR_SECONDARY: process.env.THEME_COLOR_SECONDARY || "#424242",
-
   },
 };


### PR DESCRIPTION
>  ⚠ It looks like there is a custom Babel configuration can be removed :
> ⚠ Next.js supports the following features natively:
> ⚠ 	- 'styled-components' can be enabled via 'compiler.styledComponents' in ‘next.config.js’
> ⚠ For more details configuration options, please refer https://nextjs.org/docs/architecture/nextjs-compiler#supported-features

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #48 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #46 
<!-- GitButler Footer Boundary Bottom -->

