### PR TITLE
Enable useHookAtTopLevel linting rule

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -34,7 +34,6 @@
         "noUnknownProperty": "off",
         "useExhaustiveDependencies": "off",
         "noUnusedImports": "off",
-        "useHookAtTopLevel": "off",
         "noUnusedVariables": "off",
         "useUniqueElementIds": "off"
       },

--- a/pages/account/[id].tsx
+++ b/pages/account/[id].tsx
@@ -5,7 +5,7 @@ import * as React from "react";
 import styled from "styled-components";
 import { role } from "../../src/actions";
 import { App } from "../../src/app";
-import { heading18, useTypeface } from "../../src/Materials/Typefaces";
+import { heading18, applyTypeface } from "../../src/Materials/Typefaces";
 import { Account, publicProfile, PublicProfile, roles } from "../../src/storage";
 import { DropDownInput } from "../../src/Views/Components/DropdownInput";
 import { Site } from "../../src/Views/Components/Site";
@@ -137,7 +137,7 @@ const Avatar = styled.div`
 `;
 
 const Name = styled.div`
-  ${useTypeface(heading18)};
+  ${applyTypeface(heading18)};
 `;
 
 const Form = styled.div`

--- a/pages/boulder/[id].tsx
+++ b/pages/boulder/[id].tsx
@@ -9,7 +9,7 @@ import { App } from "../../src/app";
 import { Boulder } from "../../src/storage";
 
 import { text, darkGrey, primary, secondary } from "../../src/Materials/Colors";
-import { useTypeface, copy16Bold, copy14 } from "../../src/Materials/Typefaces";
+import { applyTypeface, copy16Bold, copy14 } from "../../src/Materials/Typefaces";
 
 import { NumberInput } from "../../src/Views/Components/NumberInput";
 import { Site } from "../../src/Views/Components/Site";
@@ -272,7 +272,7 @@ function AddSetter({ app, addSetter }: { app: App; addSetter: (accountId: string
 }
 
 const AddSetterContainer = styled.div`
-  ${useTypeface(copy14)};
+  ${applyTypeface(copy14)};
   cursor: pointer;
 
   & a {
@@ -290,7 +290,7 @@ const AddSetterContainer = styled.div`
 // ----------------------------------------------------------------------------
 
 const Section = styled.div`
-  ${useTypeface(copy16Bold)}
+  ${applyTypeface(copy16Bold)}
   color: ${text};
 
   padding: 40px 0 12px;
@@ -300,7 +300,7 @@ const Section = styled.div`
 `;
 
 const SectionLabel = styled.div`
-  ${useTypeface(copy14)}
+  ${applyTypeface(copy14)}
   color: ${darkGrey};
 
   padding: 0 0 4px;

--- a/pages/email-confirmed.tsx
+++ b/pages/email-confirmed.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import styled from "styled-components";
 
-import { useTypeface, h1, copy16 } from "../src/Materials/Typefaces";
+import { applyTypeface, h1, copy16 } from "../src/Materials/Typefaces";
 
 import { Site } from "../src/Views/Components/Site";
 
@@ -27,9 +27,9 @@ const Root = styled.div`
 `;
 
 const H1 = styled.h1`
-  ${useTypeface(h1)};
+  ${applyTypeface(h1)};
 `;
 
 const P = styled.p`
-  ${useTypeface(copy16)};
+  ${applyTypeface(copy16)};
 `;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -6,7 +6,7 @@ import { App } from "../src/app";
 import { Boulder, boulderCompare } from "../src/storage";
 
 import { text } from "../src/Materials/Colors";
-import { useTypeface, copy16Bold } from "../src/Materials/Typefaces";
+import { applyTypeface, copy16Bold } from "../src/Materials/Typefaces";
 
 import { BoulderCard } from "../src/Views/Components/BoulderCard";
 import { Site } from "../src/Views/Components/Site";
@@ -85,7 +85,7 @@ const BoulderSeparator = styled.div`
   width: 100%;
   padding: 20px 16px 12px;
 
-  ${useTypeface(copy16Bold)};
+  ${applyTypeface(copy16Bold)};
   color: ${text};
 
   &:first-of-type {

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -5,7 +5,7 @@ import * as React from "react";
 import styled from "styled-components";
 import { App } from "../src/app";
 import { secondary, secondaryText, text } from "../src/Materials/Colors";
-import { copy14, copy16, copy16Bold, h1, useTypeface } from "../src/Materials/Typefaces";
+import { copy14, copy16, copy16Bold, h1, applyTypeface } from "../src/Materials/Typefaces";
 import { Site } from "../src/Views/Components/Site";
 
 interface LoginState {
@@ -197,18 +197,18 @@ export const AwaitingConfirmation = ({ email, onReset, securityCode }) => (
 );
 
 const H1 = styled.h1`
-  ${useTypeface(h1)};
+  ${applyTypeface(h1)};
   color: ${text};
   margin: 0;
 `;
 
 const P = styled.p`
-  ${useTypeface(copy16)};
+  ${applyTypeface(copy16)};
   color: ${text};
 `;
 
 const SecurityCode = styled.div`
-  ${useTypeface(copy16Bold)};
+  ${applyTypeface(copy16Bold)};
   background-color: ${secondary};
   color: ${secondaryText};
   padding: 16px 0;
@@ -229,7 +229,7 @@ const FormError = styled.div`
   top: 0;
   left: 0;
   right: 0;
-  ${useTypeface(copy14)};
+  ${applyTypeface(copy14)};
   color: #ff0000;
   margin-top: 16px;
 `;

--- a/pages/settings.tsx
+++ b/pages/settings.tsx
@@ -7,7 +7,7 @@ import { App } from "../src/app";
 import { Account } from "../src/storage";
 
 import * as C from "../src/Materials/Colors";
-import { useTypeface, heading18 } from "../src/Materials/Typefaces";
+import { applyTypeface, heading18 } from "../src/Materials/Typefaces";
 
 import { Site } from "../src/Views/Components/Site";
 import { accountAvatar } from "./account/[id]";
@@ -123,7 +123,7 @@ const Avatar = styled.div`
 `;
 
 const Name = styled.div`
-  ${useTypeface(heading18)};
+  ${applyTypeface(heading18)};
 `;
 
 const Form = styled.div`

--- a/pages/stats.tsx
+++ b/pages/stats.tsx
@@ -6,7 +6,7 @@ import { draftBoulders, role } from "../src/actions";
 import { boulderStats, BoulderStat, gradeCompare } from "../src/storage";
 import { Site } from "../src/Views/Components/Site";
 
-import { useTypeface, heading20 } from "../src/Materials/Typefaces";
+import { applyTypeface, heading20 } from "../src/Materials/Typefaces";
 
 import { SectorDistributionChart } from "../src/Components/SectorDistributionChart";
 import { GradeDistributionChart } from "../src/Components/GradeDistributionChart";
@@ -281,7 +281,7 @@ const GridItem = styled.div`
 `;
 
 const GridItemTitle = styled.div`
-  ${useTypeface(heading20)};
+  ${applyTypeface(heading20)};
   margin: 24px 24px 0;
 `;
 

--- a/src/Components/AdminBar.tsx
+++ b/src/Components/AdminBar.tsx
@@ -3,7 +3,7 @@ import styled from "styled-components";
 import Link from "next/link";
 
 import { secondary, secondaryText } from "../Materials/Colors";
-import { useTypeface, copy16 } from "../Materials/Typefaces";
+import { applyTypeface, copy16 } from "../Materials/Typefaces";
 
 const mq = {
   mobile: "@media screen and (max-width: 799px)",
@@ -23,7 +23,7 @@ const Root = styled.div`
   background: ${secondary};
   color: ${secondaryText + "DD"};
 
-  ${useTypeface(copy16)};
+  ${applyTypeface(copy16)};
   display: flex;
   align-items: center;
 

--- a/src/Components/Button.tsx
+++ b/src/Components/Button.tsx
@@ -1,11 +1,11 @@
 import styled from "styled-components";
 
-import { useTypeface, copy16Bold } from "../Materials/Typefaces";
+import { applyTypeface, copy16Bold } from "../Materials/Typefaces";
 
 import { primary, secondary, primaryText } from "../Materials/Colors";
 
 export const Button = styled.button`
-  ${useTypeface(copy16Bold)};
+  ${applyTypeface(copy16Bold)};
   width: 100%;
   border: none;
   border-radius: 0;

--- a/src/Components/GradeDistributionChart.tsx
+++ b/src/Components/GradeDistributionChart.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import styled from "styled-components";
 import Measure, { BoundingRect } from "react-measure";
 
-import { useTypeface, copy14 } from "../Materials/Typefaces";
+import { applyTypeface, copy14 } from "../Materials/Typefaces";
 import { gradeBackgroundColor, gradeBorderColor } from "../Materials/Colors";
 import { scaleBand, scaleLinear } from "d3-scale";
 import { useEnv } from "../../src/env";
@@ -150,7 +150,7 @@ const Waterline = styled.rect`
 `;
 
 const Text = styled.text`
-  ${useTypeface(copy14)};
+  ${applyTypeface(copy14)};
   fill: #222222bb;
   text-anchor: middle;
 `;

--- a/src/Components/Input.tsx
+++ b/src/Components/Input.tsx
@@ -1,9 +1,9 @@
 import styled from "styled-components";
-import { useTypeface, copy16 } from "../Materials/Typefaces";
+import { applyTypeface, copy16 } from "../Materials/Typefaces";
 import { primary, text } from "../Materials/Colors";
 
 export const Input = styled.input`
-  ${useTypeface(copy16)};
+  ${applyTypeface(copy16)};
   color: ${text}DD;
   width: 100%;
 

--- a/src/Components/Loader.tsx
+++ b/src/Components/Loader.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import styled from "styled-components";
 
-import { useTypeface, heading24 } from "../Materials/Typefaces";
+import { applyTypeface, heading24 } from "../Materials/Typefaces";
 
 import { useEnv } from "../../src/env";
 
@@ -24,6 +24,6 @@ const Root = styled.div`
 `;
 
 const Text = styled.div`
-  ${useTypeface(heading24)};
+  ${applyTypeface(heading24)};
   margin-top: 24px;
 `;

--- a/src/Components/SectorDistributionChart.tsx
+++ b/src/Components/SectorDistributionChart.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import styled from "styled-components";
 import Measure, { BoundingRect } from "react-measure";
 
-import { useTypeface, copy14 } from "../Materials/Typefaces";
+import { applyTypeface, copy14 } from "../Materials/Typefaces";
 import { scaleBand, scaleLinear } from "d3-scale";
 import { prettyPrintSector } from "../storage";
 import { useEnv } from "../../src/env";
@@ -99,7 +99,7 @@ const Rect = styled.rect`
 `;
 
 const Text = styled.text`
-  ${useTypeface(copy14)};
+  ${applyTypeface(copy14)};
   fill: #222222bb;
   text-anchor: middle;
 `;

--- a/src/Components/SetterBar.tsx
+++ b/src/Components/SetterBar.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import styled from "styled-components";
 
 import { primaryText, primary } from "../Materials/Colors";
-import { useTypeface, copy14 } from "../Materials/Typefaces";
+import { applyTypeface, copy14 } from "../Materials/Typefaces";
 import { createBoulder } from "../actions";
 import { useEnv } from "../env";
 
@@ -28,7 +28,7 @@ const Root = styled.div`
   padding: 16px 24px;
   color: ${primaryText + "DD"};
 
-  ${useTypeface(copy14)};
+  ${applyTypeface(copy14)};
 
   a {
     color: ${primary};

--- a/src/Components/SetterBlock.tsx
+++ b/src/Components/SetterBlock.tsx
@@ -6,7 +6,7 @@ import * as MUI from "./MUI";
 import { accountAvatar } from "../../pages/account/[id]";
 import { Boulder, publicProfile } from "../storage";
 
-import { useTypeface, heading28, copy14 } from "../Materials/Typefaces";
+import { applyTypeface, heading28, copy14 } from "../Materials/Typefaces";
 import { text } from "../Materials/Colors";
 import { GradeDistributionChart } from "./GradeDistributionChart";
 import { useEnv } from "../env";
@@ -70,11 +70,11 @@ const Bottom = styled.div`
 `;
 
 const Name = styled.div`
-  ${useTypeface(heading28)};
+  ${applyTypeface(heading28)};
   color: ${text};
 `;
 
 const Tagline = styled.div`
-  ${useTypeface(copy14)};
+  ${applyTypeface(copy14)};
   color: #222222bb;
 `;

--- a/src/Materials/Typefaces.ts
+++ b/src/Materials/Typefaces.ts
@@ -7,7 +7,7 @@ export interface Typeface {
   lineHeight: Property.LineHeight<string | 0>;
 }
 
-export const useTypeface = (tf: Typeface): string => `
+export const applyTypeface = (tf: Typeface): string => `
     font-family: ${tf.fontFamily};
     font-size: ${tf.fontSize};
     font-weight: ${tf.fontWeight};

--- a/src/Views/Components/BoulderCard.tsx
+++ b/src/Views/Components/BoulderCard.tsx
@@ -6,7 +6,7 @@ import Link from "next/link";
 import { accountAvatar } from "../../../pages/account/[id]";
 import { Boulder, prettyPrintSector } from "../../storage";
 
-import { useTypeface, copy16 } from "../../Materials/Typefaces";
+import { applyTypeface, copy16 } from "../../Materials/Typefaces";
 
 import { BoulderId } from "./BoulderId";
 import { useEnv } from "../../env";
@@ -104,7 +104,7 @@ const Meta = styled.div`
 `;
 
 const Sector = styled.div`
-  ${useTypeface(copy16)}
+  ${applyTypeface(copy16)}
   white-space: nowrap;
   line-height: 1;
   text-transform: uppercase;

--- a/src/Views/Components/BoulderDetails.tsx
+++ b/src/Views/Components/BoulderDetails.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import { Boulder } from "../../storage";
 
 import { text } from "../../Materials/Colors";
-import { useTypeface, copy16Bold } from "../../Materials/Typefaces";
+import { applyTypeface, copy16Bold } from "../../Materials/Typefaces";
 
 import { SectorPicker } from "./SectorPicker";
 import { BoulderSetterCard } from "./BoulderSetterCard";
@@ -35,7 +35,7 @@ const Root = styled.div`
 `;
 
 const Section = styled.div`
-  ${useTypeface(copy16Bold)};
+  ${applyTypeface(copy16Bold)};
   color: ${text};
 
   padding: 40px 0 12px;

--- a/src/Views/Components/BoulderSetterCard.tsx
+++ b/src/Views/Components/BoulderSetterCard.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import styled from "styled-components";
 
 import { text } from "../../Materials/Colors";
-import { useTypeface, copy16 } from "../../Materials/Typefaces";
+import { applyTypeface, copy16 } from "../../Materials/Typefaces";
 import { accountPublicProfile } from "../../../pages/account/[id]";
 import { useEnv } from "../../env";
 
@@ -52,7 +52,7 @@ const SetterImage = styled.img`
 `;
 
 const SetterName = styled.div`
-  ${useTypeface(copy16)};
+  ${applyTypeface(copy16)};
   color: ${text};
   text-align: center;
   margin: 10px 24px 24px 10px;

--- a/src/Views/Components/Stats/Internal.tsx
+++ b/src/Views/Components/Stats/Internal.tsx
@@ -1,10 +1,10 @@
 import styled from "styled-components";
 
 import { text, lightGrey } from "../../../Materials/Colors";
-import { useTypeface, copy16Bold, copy14 } from "../../../Materials/Typefaces";
+import { applyTypeface, copy16Bold, copy14 } from "../../../Materials/Typefaces";
 
 export const Section = styled.div`
-  ${useTypeface(copy16Bold)}
+  ${applyTypeface(copy16Bold)}
   color: ${text};
 
   padding: 80px 0 20px;
@@ -14,7 +14,7 @@ export const Section = styled.div`
 `;
 
 export const SectionLink = styled.span`
-${useTypeface(copy14)}
+${applyTypeface(copy14)}
 color: ${lightGrey};
 
 margin-left: 6px;

--- a/src/Views/Components/Stats/SetterSelector.tsx
+++ b/src/Views/Components/Stats/SetterSelector.tsx
@@ -4,7 +4,7 @@ import styled from "styled-components";
 import { accountPublicProfile } from "../../../../pages/account/[id]";
 
 import { text, lightGrey } from "../../../Materials/Colors";
-import { useTypeface, copy14 } from "../../../Materials/Typefaces";
+import { applyTypeface, copy14 } from "../../../Materials/Typefaces";
 
 import { Section, SectionLink } from "./Internal";
 
@@ -83,7 +83,7 @@ opacity: ${({ $isSelected }) => ($isSelected ? 1 : 0.2)}
 `;
 
 const SetterName = styled.div<{ $isSelected: boolean }>`
-  ${useTypeface(copy14)};
+  ${applyTypeface(copy14)};
   transition all .2s;
   color: ${({ $isSelected }) => ($isSelected ? text : lightGrey)};
 `;

--- a/src/Views/Components/Stats/Visualization.tsx
+++ b/src/Views/Components/Stats/Visualization.tsx
@@ -11,7 +11,7 @@ import { BoulderStat } from "../../../storage";
 import { useEnv } from "../../../../src/env";
 
 import { yellow100, green100, orange100, blue100, red100 } from "../../../Materials/Colors";
-import { useTypeface, copy14, copy14Bold } from "../../../Materials/Typefaces";
+import { applyTypeface, copy14, copy14Bold } from "../../../Materials/Typefaces";
 
 const curve = curveLinear;
 
@@ -311,11 +311,11 @@ export class GridLabels extends React.PureComponent<GridProps> {
 }
 
 const GridLabel = styled.text`
-  ${useTypeface(copy14)};
+  ${applyTypeface(copy14)};
   fill: #666;
 `;
 
 const ZeroGridLabel = styled.text`
-  ${useTypeface(copy14Bold)};
+  ${applyTypeface(copy14Bold)};
   fill: #666;
 `;


### PR DESCRIPTION
Functions with a `use` prefix have special meaning in React projects. These names are resered for React Hooks. We use the `use` prefix for a non-hook function (`useTypeface`). The easiest way to allow the useHookAtTopLevel rule to be enabled is to rename the function to not use a `use` prefix.

The changes in this PR are basically:

 - Enable useHookAtTopLevel linting rule.
 - Rename `useTypeface` to `applyTypeface`. 

No other linting failures are present. This means all React hooks are being used correctly. 